### PR TITLE
URL autolink

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,5 +9,10 @@ module.exports = {
     editLinks: true,
     editLinkText: 'Edit this page on GitHub'
   },
+  markdown: {
+    extendMarkdown: md => {
+      md.set({ linkify: true })
+    }
+  },
   plugins: ['@vuepress/register-components']
 }


### PR DESCRIPTION
markdown中のURLに自動でリンクを貼るようにします。
GFMでは自動リンクが有効になっているためこの機能を有効にするとGFMに近い挙動になります。

markdown-itのオプションはこちら https://github.com/markdown-it/markdown-it#init-with-presets-and-options