### PR TITLE
技術文書向けのtextlintルールを導入

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,5 +1,8 @@
 {
     "rules": {
-        "no-nfd": true
+        "preset-ja-technical-writing": {
+            "no-exclamation-question-mark": false,
+            "ja-no-weak-phrase": false
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "find . -H -type f -name '*.md' -and -not -iwholename '*/node_modules/*' -exec npx textlint {} +"
+    "test": "find -H . -type f -name '*.md' -and -not -iwholename '*/node_modules/*' -exec npx textlint {} +"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,6 @@
   "homepage": "https://github.com/iij/bootcamp#readme",
   "dependencies": {
     "textlint": "^11.3.1",
-    "textlint-rule-no-nfd": "^1.0.1"
+    "textlint-rule-preset-ja-technical-writing": "^3.1.3"
   }
 }


### PR DESCRIPTION
技術文書向けのtextlintルール [textlint-rule-preset-ja-technical-writing](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing) を導入します。

マニュアルとか仕様書を書くためのルールでありデフォルト設定が結構きつめで一部緩和してありますが、読みやすい文書を作る上では大事なルールが多いと思います。
reviewdogは差分がないところには反応しないので更新するときに参考にしてもらうことを想定しています。