### PR TITLE
linterが競合するためtechboosterの単語帳を外す

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,6 @@
             "prh": {
                 "rulePaths": [
                     "node_modules/prh/prh-rules/media/WEB+DB_PRESS.yml",
-                    "node_modules/prh/prh-rules/media/techbooster.yml",
                     "node_modules/prh/prh-rules/languages/ja/typo.yml"
                 ]
             }


### PR DESCRIPTION
`WEB+DB_PRESS.yml`と`techbooster.yml`でlinterが競合するため、techboosterを外そうと思います。外す以外に上手いやり方があれば教えてください。

競合の例

`WEB+DB_PRESS.yml`
```yml
  - pattern: /([^排人])他([^ァ-ヶ社者人方])/
    expected: $1ほか$2
  - pattern: はじめて
    expected: 初めて
```

`techbooster.yml`
```yml
  - expected: 他の
    pattern:  ほかの
    prh: ひらがなで書かず、漢字で書くと読みやすくなります
  - expected: はじめて
    pattern:  初めて
    prh: 漢字で書かず、ひらがなで書くと読みやすくなります。
```