### PR TITLE
<header-table/>を使うページでも<title>を適切に入れる。

### DIFF
--- a/src/database/mongodb/README.md
+++ b/src/database/mongodb/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: MongoDBを触ってみよう
 description: MongoDBに対してクエリを投げながら、レプリカセットなど特徴的な機能について紹介します。
 time: 1h
 prior_knowledge: なし
@@ -7,7 +8,7 @@ prior_knowledge: なし
 
 <header-table/>
 
-# MongoDBを触ってみよう
+# {{$page.frontmatter.title}}
 
 [資料はこちら](/bootcamp/MongoDB.pdf)
 

--- a/src/database/mysql/README.md
+++ b/src/database/mysql/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: MySQLを触ってみる
 description: MySQL を立ち上げSQLを触ることで、RDBの勘所を学びます。
 time: 1h
 prior_knowledge: なし
@@ -7,7 +8,7 @@ prior_knowledge: なし
 
 <header-table/>
 
-# MySQLを触ってみる
+# {{$page.frontmatter.title}}
 
 [資料はこちら](/bootcamp/MySQL.pdf)
 

--- a/src/development/docker/docker-compose/README.md
+++ b/src/development/docker/docker-compose/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: 開発環境をDocker Composeで構築
 description: Docker Compose を用いて開発環境を構築します。
 time: 1h
 prior_knowledge: docker
@@ -7,7 +8,7 @@ prior_knowledge: docker
 
 <header-table/>
 
-# 開発環境をDocker Composeで構築
+# {{$page.frontmatter.title}}
 
 ## 事前準備
 * この講義では ```docker-compose``` コマンドを使います。

--- a/src/development/docker/docker/README.md
+++ b/src/development/docker/docker/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: Dockerを触ってみよう
 description: Docker の概要を学び、コンテナ操作を体験します
 time: 1h
 prior_knowledge: 仮想化、CUI 操作
@@ -7,7 +8,7 @@ prior_knowledge: 仮想化、CUI 操作
 
 <header-table/>
 
-# Dockerを触ってみよう
+# {{$page.frontmatter.title}}
 
 ## おさらい
 

--- a/src/development/git/README.md
+++ b/src/development/git/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2021, Internet Initiative Japan Inc.
+title: Gitの使い方
 description: バージョン管理システムとしてgitを利用し、変更を管理することの大切さを学びます。
 time: 1.5時間
 prior_knowledge: コマンドラインの基礎的な使い方
@@ -7,7 +8,7 @@ prior_knowledge: コマンドラインの基礎的な使い方
 
 <header-table/>
 
-# Gitの使い方
+# {{$page.frontmatter.title}}
 
 ## 0. まえがきと下準備
 

--- a/src/development/github/README.md
+++ b/src/development/github/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2021, Internet Initiative Japan Inc.
+title: GitHub 入門
 description: バージョン管理システムとしてgitを利用し、変更を管理することの大切さを学びます。
 time: 1.5時間
 prior_knowledge: コマンドラインの基礎的な使い方、Gitの使い方
@@ -7,7 +8,7 @@ prior_knowledge: コマンドラインの基礎的な使い方、Gitの使い方
 
 <header-table/>
 
-# GitHub 入門
+# {{$page.frontmatter.title}}
 
 [GitHub](https://github.com/)とはGitのリモートリポジトリをホスティングしてくれるサービスです。
 IIJでは社内で使えるGitHub Enterpriseを提供しています。

--- a/src/frontend/jquery/README.md
+++ b/src/frontend/jquery/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: jQueryを触ってみよう
 description: JavaScriptライブラリであるjQueryを通してHTMLのDOM操作などについて学びます。
 time: 1h
 prior_knowledge: JavaScript
@@ -7,7 +8,7 @@ prior_knowledge: JavaScript
 
 <header-table/>
 
-# jQueryを触ってみよう
+# {{$page.frontmatter.title}}
 
 ## 事前準備
 

--- a/src/frontend/react/README.md
+++ b/src/frontend/react/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: React でシングルページアプリケーションを書こう
 description: React でシングルページアプリケーションを書こう
 time: 2h
 prior_knowledge: 特になし
@@ -15,7 +16,7 @@ cd bootcamp/src/frontend/react
 docker-compose up -d
 ```
 
-# React でシングルページアプリケーションを書こう
+# {{$page.frontmatter.title}}
 
 ## 始めに
 

--- a/src/init/hello-bootcamp/README.md
+++ b/src/init/hello-bootcamp/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2021, Internet Initiative Japan Inc.
+title: ハンズオン事前準備
 description: ハンズオン事前準備
 time: 0.5h
 prior_knowledge: なし
@@ -7,7 +8,7 @@ prior_knowledge: なし
 
 <header-table/>
 
-# ハンズオン事前準備
+# {{$page.frontmatter.title}}
 
 各ハンズオンに取り組む前に、各ハンズオン用の環境を [Docker](https://www.docker.com/) で動かせるように準備します。
 
@@ -209,7 +210,7 @@ windows
 
 ```terminal
 $ docker run --name test-nginx -p 8080:80 --mount type=bind,source=%CD%/content,target=/usr/share/nginx/html,ro -d nginx
-  
+
 47fb496ed83cb26558874e8fd6b6fff4303031a2b24f827a938310ee9646c638
 ```
 

--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: GoでWebアプリケーションを作る
 description: Go言語を使って簡単なWebアプリケーションを作ります
 time: 1.5h
 prior_knowledge: golang
@@ -7,7 +8,7 @@ prior_knowledge: golang
 
 <header-table/>
 
-# GoでWebアプリケーションを作る
+# {{$page.frontmatter.title}}
 
 ## 0. この講義について
 ### 0.1. この講義の目的

--- a/src/server-app/java/README.md
+++ b/src/server-app/java/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: Java; springboot
 description: SpringBootを使ったアプリ開発を試してみるハンズオンです
 time: 2h
 prior_knowledge: 特になし
@@ -7,7 +8,7 @@ prior_knowledge: 特になし
 
 <header-table/>
 
-# Java; springboot
+# {{$page.frontmatter.title}}
 
 IIJ Bootcamp java; SpringBoot に関する資料です。あらかじめ Bootcamp のリポジトリをローカルへ clone し、下準備まで終わらせておいてください。
 

--- a/src/server-app/node/README.md
+++ b/src/server-app/node/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2020, Internet Initiative Japan Inc.
+title: Node.jsでWebアプリを作る
 description: Node.jsを使ったアプリケーション開発のハンズオンです
 time: 1h
 prior_knowledge: JavaScript
@@ -7,7 +8,7 @@ prior_knowledge: JavaScript
 
 <header-table/>
 
-# Node.jsでWebアプリを作る
+# {{$page.frontmatter.title}}
 
 ## 下準備
 

--- a/src/server-app/rails/README.md
+++ b/src/server-app/rails/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: Ruby on RailsでWebアプリを作る
 description: Railsによるサーバーアプリ実装の基礎についてハンズオンしてみましょう
 time: 1h
 prior_knowledge: 特になし
@@ -7,7 +8,7 @@ prior_knowledge: 特になし
 
 <header-table/>
 
-# Ruby on RailsでWebアプリを作る
+# {{$page.frontmatter.title}}
 
 ## Ruby on Railsとは
 

--- a/src/web-server/hosting/README.md
+++ b/src/web-server/hosting/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: 動的アプリのホスティング
 description: rubyやgoとnginx/apacheを組み合わせて動的アプリのホスティングに挑戦します
 time: 1h
 prior_knowledge: ruby go apache nginx
@@ -7,7 +8,7 @@ prior_knowledge: ruby go apache nginx
 
 <header-table/>
 
-# 動的アプリのホスティング
+# {{$page.frontmatter.title}}
 
 ## 事前準備
 

--- a/src/web-server/nginx/README.md
+++ b/src/web-server/nginx/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: nginxを触ってみよう
 description: nginxの紹介と実際に動かしてみるハンズオンです
 time: 1h
 prior_knowledge: なし
@@ -7,7 +8,7 @@ prior_knowledge: なし
 
 <header-table/>
 
-# nginxを触ってみよう
+# {{$page.frontmatter.title}}
 
 [資料はこちら](/bootcamp/NGINX.pdf)
 

--- a/src/web-server/overview/README.md
+++ b/src/web-server/overview/README.md
@@ -1,5 +1,6 @@
 ---
 footer: CC BY-SA Licensed | Copyright (c) 2019, Internet Initiative Japan Inc.
+title: Webサーバー Overview
 description: 世の中で使われるWebサーバーの種類や実際に使う際の構成例について紹介します
 time: 1h
 prior_knowledge: なし
@@ -7,7 +8,7 @@ prior_knowledge: なし
 
 <header-table/>
 
-# Webサーバー Overview
+# {{$page.frontmatter.title}}
 
 [資料はこちら](/bootcamp/webserver-overview.pdf)
 


### PR DESCRIPTION
一部のページで<title>が "IIJ Bootcamp" になってしまい、ブラウザの
タブやヒストリが見にくくなっていた問題を修正した。

<header-table/>を使っていないページでは先頭の h1 が<title>に反映
されるが、<header-table/>を使っているページではそれが機能せず、
サイトデフォルトの "IIJ Bootcamp" となってしまう。

修正方法は、うまい手が見つからなかったため、各ページの frontmatter
で title を設定しつつページ内の h1 からそれを参照するようにした。