### PR TITLE
web/golangの2022年度改定版

### DIFF
--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -154,7 +154,12 @@ Go の [Gopher](https://golang.org/doc/gopher/gopherbw.png) がかわいいで�
 もしコンテナを実行していないようであれあば、以下のコマンドを実行してください。  
 ```shell
 :# TERMINAL 0
-$ docker run --name go-tutor -it --rm hinoshiba/go-tutor:v2021r2 /bin/bash
+
+:# vim,emacs,nano派の人はこちら
+$ docker run --name go-tutor -it --rm jo7oem/go-tutor:v2022 /bin/bash
+
+:# VSCode派の人はこちら
+$ docker run --name go-tutor-vscode -p 8888:8888 -itd --rm jo7oem/go-tutor-vscode
 ```
 
 ハンズオンでは、こちらから指示したpathに、ディレクトリやファイルを作成してもらい、Go言語に触れてもらいます。  
@@ -182,6 +187,8 @@ Go言語で作成されたソースコードの実行方法は2つあります�
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/2_helloworld/hello/
+
+$ cd /go/src/go_tutorial/2_helloworld/hello/ 
 $ <お好きなエディタ> main.go
 $ go run main.go
 ```
@@ -198,6 +205,7 @@ $ go run main.go
 :recycle: 2.1.1.1. 結果
 ```shell
 :# TERMINAL 0
+
 $ go run main.go
 Hello, W0rld!!
 ```
@@ -206,6 +214,7 @@ Hello, W0rld!!
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/2_helloworld/hello/
+
 $ go build main.go
 $ ls
 $ file ./main
@@ -215,6 +224,7 @@ $ ./main
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/2_helloworld/hello/
+
 $ go build main.go
 $ ls
 main  main.go
@@ -235,6 +245,7 @@ Hello, W0rld!!
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/2_helloworld/hello/
+
 $ GOOS=windows GOARCH=amd64 go build main.go
 $ ls
 $ file ./main.exe
@@ -243,6 +254,7 @@ $ file ./main.exe
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/2_helloworld/hello/
+
 $ GOOS=windows GOARCH=amd64 go build main.go
 $ ls
 main main.exe main.go
@@ -262,11 +274,51 @@ android/arm64
 #...省略
 ```
 
-# 3. 変数の定義方法確認 ( 10 min )
-本章では、変数の定義方法の確認と、変数定義に失敗しているソースコードを修正してもらいます。  
+# 3. 変数とその定義方法 ( 15 min )
+本章では、変数とその定義方法についての確認と、変数定義に失敗しているソースコードを修正してもらいます。  
 
-## 3.1. 変数定義方法
-Go言語では、変数の定義記法が3つあります。  
+## 3.1. 変数の種類
+Go言語は、静的型付け言語であるためコンパイル時に変数に紐付いた型の情報に整合性があるか検証されます。
+この講義では深く触れませんが、下にGo言語における方の種類について簡単な説明を記載します。
+興味のある方は[公式ドキュメント](https://go.dev/ref/spec#Types)を見てみてください。
+* 組み込み型
+  * 整数
+    * `int`,`int8`,`int16`,`int32`,`int64`
+    * `uint`,`uint8`,`uint16`,`uint32`,`uint64`
+    * `uintptr`
+    * `byte`
+    * `rune`
+  * 浮動小数点
+    * `float32`,`float64`
+  * 複素数
+    * `complex64`,`complex128`
+  * 文字列
+    * `string`
+  
+		:rocket: `string`を構成する文字は`rune`で構成されます
+  * 真偽値
+    * `bool`
+  * エラー
+    * `error`
+* コンポジット型
+	
+	0個以上の変数をひとまとまりの集合として表した型です
+  * 構造体 (`struct`)
+  * 配列 (`array`) 
+  * スライス (`slice`)
+  * マップ (`map`)
+  * チャンネル (`channel`)
+* ユーザー定義型
+
+	組み込み型やコンポジット型を元にユーザーが定義した型です
+* `Interface型` 
+
+	rocket: これまで説明した型はデータがメモリ上にどのように表現されているかという観点から区別されていました。
+	この`interface型`は方がどう振る舞うか(型にどんなメソッドが実装されているか)という観点で区別され、0個以上のメソッドから構成されます。
+	
+
+## 3.2. 変数定義方法
+Go言語では、変数の定義方法が3つあります。
 
 1. `var <変数名> <型>`
 	* 例: `var Hensu string`
@@ -279,16 +331,15 @@ Go言語では、変数の定義記法が3つあります。
 	* 型指定有り。変数初期値の指定有り
 
 予期せぬ型が変数に定義されないよう、最初のうち（書いている型をイメージできるまで）は、1か3の書き方をお勧めします。  
-予期せぬ型が変数に定義されうる例として、`interface型` というものが存在します。  
-本講義では、`interface型` は扱わない為、説明は割愛しますが、使い方として、`なんでも型` のような使い方ができます。  
+予期せぬ型が変数に定義されうる例として、`interface型` があります。  
+本講義では、`interface型` は扱わない為説明は割愛しますが、`なんでも型(any)` のような使い方ができます。  
 変数`なんでも型`が示しているのは、int型だと思っていたらstring型だった。というようなケースもおきえるので、注意が必要です。  
-:rocket: 同一PublicMethodを保有する、異なる型のポインタを同じ変数として扱うポインタ変数領域のようなものです。同一PublicMethodをAny指定することで、なんでも渡せるポインタ領域を作成できます。  
 
 ##### :rocket: Tips: privateとPublicの指定方法
 Go言語の名前空間は、`private`は先頭小文字。`Public`が先頭大文字と決まっています。  
 packageに含める要素（変数や関数、構造体や構造体の要素など）をpackageの外部から参照させたい場合、先頭大文字の変数名とするようご注意ください。  
 
-## 3.2. 不具合箇所は、最高の講師に教えてもらおう
+## 3.3. 不具合箇所は、最高の講師に教えてもらおう
 Go言語では、書き方を間違えているととても丁寧に教えてくれる強い味方がいます。  
 それは、コンパイラ（`go build`）です。  
 「うーん、あ、この辺のソースみた？」とだけ返してくる先輩に比べ、「3行目、6文字目。変数定義されていないよ！？」と場所まで指定して教えてくれます。  
@@ -301,28 +352,32 @@ Go言語では、書き方を間違えているととても丁寧に教えてく
 エラーが多いと、数個のエラーの後に`too many error....`と続き、全てのエラーを教えてくれないことがあります。  
 しょうがないので、教えてもらっているエラーから対処していきましょう。  
 
-### :computer: 3.2.1. 以下のコマンドを実行して、修正箇所を認識てみよう。  
+### :computer: 3.3.1. 以下のコマンドを実行して、修正箇所を認識てみよう。  
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/3_var/plzfixme/
+
+$ cd /go/src/go_tutorial/3_var/plzfixme/
 $ go run main.go
 ```
 
-:recycle: 3.2.1. 結果
+:recycle: 3.3.1. 結果
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/3_var/plzfixme/
+
 $ go run main.go
 # command-line-arguments
 ./main.go:6:2: undefined: WatashiNoHensu
 ./main.go:7:14: undefined: WatashiNoHensu
 ```
 
-## 3.3. 不具合の修正
+## 3.4. 不具合の修正
 ### :computer: 3.3.1. ソースコードを修正し、エラーを無くしてみよう。  
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/3_var/plzfixme/
+
 $ <お好きなエディタ> main.go
 $ go run main.go
 ```
@@ -337,15 +392,16 @@ $ go run main.go
 		fmt.Println(Watashi_no_Hensu)     //./main.go:7:14: undefined: Watashi_no_Hensu
 	}
 	```
-:recycle: 3.3.1. 結果
+:recycle: 3.4.1. 結果
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/3_var/plzfixme/
+
 $ <お好きなエディタ> main.go
 $ go run main.go
 GYUDON
 ```
-### :rocket: :computer: 3.3.2. 変数定義方法が3種類を全て試してみよう。
+### :rocket: :computer: 3.4.2. 変数定義方法が3種類を全て試してみよう。
 
 # 4. 関数 ( 10 min )
 本章では、関数の定義方法と、Goっぽい関数の扱われ方について、確認してもらいます。  
@@ -449,6 +505,8 @@ func main() {
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/4_funcy/monkey/
+
+$ cd /go/src/go_tutorial/4_funcy/monkey/
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go
 ```
@@ -480,6 +538,7 @@ $ go run eaters.go
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/4_funcy/monkey/
+
 $ go run eaters.go
 GYUDON
 cannt eat: 
@@ -532,6 +591,9 @@ if _, err := Writer(); err != nil {
 :# TERMINAL 0
 :# COPY /go/src/go_tutorial/4_funcy/monkey/eaters.go /go/src/go_tutorial/4_funcy/likego/eaters.go
 :# WORKPATH /go/src/go_tutorial/4_funcy/likego/
+
+$ cp /go/src/go_tutorial/4_funcy/monkey/eaters.go /go/src/go_tutorial/4_funcy/likego/eaters.go
+$ cd /go/src/go_tutorial/4_funcy/likego/
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go
 ```
@@ -552,12 +614,12 @@ $ go run eaters.go
 	func main() {
 		var name1 string = "GYUDON"
 		if _, err := Eat(name1); err != nil {
-			fmt.Println("cannt eat: ", err)
+			fmt.Println("cannot eat: ", err)
 		}
 
 		var name2 string = ""
 		if _, err := Eat(name2); err != nil {
-			fmt.Println("cannt eat: ", err)
+			fmt.Println("cannot eat: ", err)
 		}
 	}
 	```
@@ -565,6 +627,7 @@ $ go run eaters.go
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/4_funcy/likego/
+
 $ go run eaters.go
 GYUDON
 cannot eat: name is empty.
@@ -647,6 +710,8 @@ import (
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/5_package/fixFunckyMonkey/
+
+$ cd /go/src/go_tutorial/5_package/fixFunckyMonkey/
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go
 $ go run eaters.go > /dev/null
@@ -684,6 +749,7 @@ $ go run eaters.go > /dev/null
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/5_package/fixFunckyMonkey/
+
 $ go run eaters.go
 GYUDON
 cannot eat: 'name is empty.'
@@ -703,6 +769,9 @@ cannot eat: 'name is empty.'
 :# TERMINAL 0
 :# COPY /go/src/go_tutorial/5_package/fixFunckyMonkey/eaters.go /go/src/go_tutorial/5_package/notKinkyuJi/eaters.go
 :# WORKPATH /go/src/go_tutorial/5_package/notKinkyuJi/
+
+$ cp /go/src/go_tutorial/5_package/fixFunckyMonkey/eaters.go /go/src/go_tutorial/5_package/notKinkyuJi/eaters.go
+$ cd /go/src/go_tutorial/5_package/notKinkyuJi/ 
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go
@@ -922,6 +991,10 @@ type GYUDONYA struct {
 :# COPY /go/src/go_tutorial/5_package/notKinkyuJi/eaters.go /go/src/go_tutorial/6_struct/weakShop/eaters.go
 :# COPY /go/src/go_tutorial/5_package/notKinkyuJi/shop/shop.go /go/src/go_tutorial/6_struct/weakShop/shop/shop.go
 :# WORKPATH /go/src/go_tutorial/6_struct/weakShop/
+
+$ cp /go/src/go_tutorial/5_package/notKinkyuJi/eaters.go /go/src/go_tutorial/6_struct/weakShop/eaters.go
+$ cp /go/src/go_tutorial/5_package/notKinkyuJi/shop/shop.go /go/src/go_tutorial/6_struct/weakShop/shop/shop.go
+$ cd /go/src/go_tutorial/6_struct/weakShop/
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go
@@ -977,6 +1050,7 @@ $ go run eaters.go
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/6_struct/weakShop/
+
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> gyudon-httpd.go
 $ go run eaters.go
@@ -991,6 +1065,7 @@ NegitamaGyudon
 ## 7.0. 準備
 本章以降、複数のターミナルを用い、ハンズオンいただきます。  
 既存のコンテナに接続し利用するため、それぞれターミナルを起動し、以下コマンドを実行ください。  
+VSCodeをお使いの方はターミナルを追加で起動してください。
 ```shell
 :# TERMINAL 1
 $ docker exec -it go-tutor /bin/bash
@@ -1023,9 +1098,14 @@ func main() {
 :# COPY /go/src/go_tutorial/6_struct/weakShop/shop/shop.go /go/src/go_tutorial/7_webapp/weakShop/shop/shop.go
 :# COPY /go/src/go_tutorial/6_struct/weakShop/eaters.go /go/src/go_tutorial/7_webapp/weakShop/gyudon-httpd.go
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
+$ cp /go/src/go_tutorial/6_struct/weakShop/shop/shop.go /go/src/go_tutorial/7_webapp/weakShop/shop/shop.go
+$ cp /go/src/go_tutorial/6_struct/weakShop/eaters.go /go/src/go_tutorial/7_webapp/weakShop/gyudon-httpd.go
+$ cd /go/src/go_tutorial/7_webapp/weakShop/
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> gyudon-httpd.go
 $ go run gyudon-httpd.go
+
 
 :# TERMINAL 1
 $ curl http://localhost:8080/
@@ -1080,9 +1160,11 @@ $ curl http://localhost:8080/
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> gyudon-httpd.go
 $ go run gyudon-httpd.go
+
 
 :# TERMINAL 1
 $ curl http://localhost:8080/
@@ -1092,7 +1174,7 @@ $ curl http://localhost:8080/
 :computer: 7.2. 後処理
 ```shell
 :# TERMINAL 0
-:# Ctrl + C で、gyudon-httpd.goをKillください
+:# Ctrl + C で、gyudon-httpd.goをKillしてください
 ```
 
 ## 7.3. Goroutineに触れる
@@ -1116,11 +1198,14 @@ HTTPサーバで、他者の処理が終わらないと利用できないなん�
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
 $ go run gyudon-httpd.go
+
 
 :# TERMINAL 1
 $ time curl http://localhost:8080/
 :# 10秒程度待機する
+
 
 :# TERMINAL 2
 $ time curl http://localhost:8080/
@@ -1130,8 +1215,10 @@ $ time curl http://localhost:8080/
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
 $ go run gyudon-httpd.go
 :# 何も出力されない場合、実行中です。続くハンズオンを実施ください
+
 
 :# TERMINAL 1
 $ time curl http://localhost:8080/
@@ -1183,9 +1270,11 @@ AさんとBさんに、同時に牛丼を食べてもらう方法は、簡単で
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
 $ <お好きなエディタ> http/zakohttp.go
 $ go run gyudon-httpd.go
 :# 何も出力されない場合、実行中です。続くハンズオンを実施ください
+
 
 :# TERMINAL 1
 $ time curl http://localhost:8080/
@@ -1204,9 +1293,11 @@ $ time curl http://localhost:8080/
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/7_webapp/weakShop/
+
 $ <お好きなエディタ> http/zakohttp.go
 $ go run gyudon-httpd.go
 :# 何も出力されない場合、実行中です。続くハンズオンを実施ください
+
 
 :# TERMINAL 1
 $ docker exec -it go-tutor /bin/bash

--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -315,6 +315,7 @@ Go言語は、静的型付け言語であるためコンパイル時に変数に
 
 	rocket: これまで説明した型はデータがメモリ上にどのように表現されているかという観点から区別されていました。
 	この`interface型`は方がどう振る舞うか(型にどんなメソッドが実装されているか)という観点で区別され、0個以上のメソッドから構成されます。
+	また、[Go1.18からGenericsが追加](https://tip.golang.org/doc/go1.18#generics)されました。これにより、`interface`に型の情報を組み込むことができるようになりました。
 	
 
 ## 3.2. 変数定義方法
@@ -407,9 +408,11 @@ GYUDON
 本章では、関数の定義方法と、Goっぽい関数の扱われ方について、確認してもらいます。  
 
 ## 4.1. 関数の定義
-Go言語では、`func`から始まる形で、関数を定義できます。フォーマットは以下の通りです  
+Go言語では、`func`から始まる形で、関数を定義できます。フォーマットは以下の通りです。
+
+:rocket: 
 ```go
-func <関数名>([<引数1>, <引数2>...]) [(<戻り値1>, <戻り値2>...)] {
+func <関数名>[<型パラメータ1>,<型パラメータ2> ...]([<引数1>, <引数2>...]) [(<戻り値1>, <戻り値2>...)] {
 	<処理>
 }
 ```
@@ -438,7 +441,8 @@ func myFunc(name string, age uint) (bool, error) {
 	return find, result
 }
 ```
-関数の基本的な定義方法は以上です。  
+関数の基本的な定義方法は以上です。
+
 
 ##### :rocket: 変数名を戻り値の定義で、合わせて定義する方法もあります。  
 変数の名前スコープが、関数内全体のスコープになり、認識すべき範囲が広がるため、執筆者は、あまり扱いません。  
@@ -446,6 +450,21 @@ func myFunc(name string, age uint) (bool, error) {
 func myFunc(name string, age uint) (find bool, result error) {
 	<処理>
 	return find, result
+}
+```
+
+##### :rocket: 型パラメータの使用 (Generics)
+`interface型`を用いることで任意の型を受け付けられる関数を作ることができます。
+便利なようですが、実行時に型を解決するため意図しない挙動を取る可能性があります。
+Go1.18でGenericsが導入されコンパイル時に型を解決することが可能になりました。
+興味のあるひとは[Genericsのチュートリアル](https://go.dev/doc/tutorial/generics)をやってみてください。
+```go
+type Number interface {
+	int64 | float64
+}
+func myFunc[T any,N Number](hoge []T, fuga N) []T {
+	<処理>
+	return res
 }
 ```
 

--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -537,8 +537,10 @@ $ go run eaters.go
 
 	func Eat(name string) bool {
 		<nameが空白か比較する>
+		<nameが空白ならば> {
+ 			<`return false`を行う>
+		 }
 		<nameが空白以外ならば、`fmt.Println(name)`を実行し、`return true`を行う>
-		<nameが空白ならば、`return false`を行う>
 	}
 
 	func main() {
@@ -837,6 +839,7 @@ $ go run eaters.go
 ```shell
 :# TERMINAL 0
 :# WORKPATH /go/src/go_tutorial/5_package/notKinkyuJi/
+
 $ <お好きなエディタ> shop/shop.go
 $ <お好きなエディタ> eaters.go
 $ go run eaters.go

--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -313,7 +313,7 @@ Go言語は、静的型付け言語であるためコンパイル時に変数に
 	組み込み型やコンポジット型を元にユーザーが定義した型です
 * `Interface型` 
 
-	rocket: これまで説明した型はデータがメモリ上にどのように表現されているかという観点から区別されていました。
+	:rocket: これまで説明した型はデータがメモリ上にどのように表現されているかという観点から区別されていました。
 	この`interface型`は方がどう振る舞うか(型にどんなメソッドが実装されているか)という観点で区別され、0個以上のメソッドから構成されます。
 	また、[Go1.18からGenericsが追加](https://tip.golang.org/doc/go1.18#generics)されました。これにより、`interface`に型の情報を組み込むことができるようになりました。
 	
@@ -412,7 +412,7 @@ Go言語では、`func`から始まる形で、関数を定義できます。フ
 
 :rocket: 
 ```go
-func <関数名>[<型パラメータ1>,<型パラメータ2> ...]([<引数1>, <引数2>...]) [(<戻り値1>, <戻り値2>...)] {
+func <関数名>[[<型パラメータ1>,<型パラメータ2> ...]]([<引数1>, <引数2>...]) [(<戻り値1>, <戻り値2>...)] {
 	<処理>
 }
 ```
@@ -1108,6 +1108,9 @@ func httphandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/", httphandler)   //どこのPathで、どんな処理をするか
 	http.ListenAndServe("localhost:8080", nil) //どの接続元(ホスト名:ポート)で、サーバを起動するか
+	if err != nil {
+		panic(err)
+	}
 }
 ```
 
@@ -1176,6 +1179,9 @@ $ curl http://localhost:8080/
 		myshop := shop.NewGyudon()
 		http.HandleFunc("/", myshop.Eat)
 		http.ListenAndServe("localhost:8080", nil)
+		if err != nil {
+			panic(err)
+		}
 	}
 	```
 :recycle: 7.2. 結果

--- a/src/server-app/go/README.md
+++ b/src/server-app/go/README.md
@@ -159,7 +159,7 @@ Go の [Gopher](https://golang.org/doc/gopher/gopherbw.png) がかわいいで�
 $ docker run --name go-tutor -it --rm jo7oem/go-tutor:v2022 /bin/bash
 
 :# VSCode派の人はこちら
-$ docker run --name go-tutor-vscode -p 8888:8888 -itd --rm jo7oem/go-tutor-vscode
+$ docker run --name go-tutor-vscode -p 8888:8888 -d --rm jo7oem/go-tutor-vscode:v2022
 ```
 
 ハンズオンでは、こちらから指示したpathに、ディレクトリやファイルを作成してもらい、Go言語に触れてもらいます。  

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.19 AS builder
 LABEL maintainer="jo7oem@ume-ch.net"
 
-ENV GOPATH /go/src
-
-ENV LANG ja_JP.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG ja_JP.UTF-8
+
+ENV GOPATH /go/src
+ENV GO111MODULE=off
 
 RUN apt-get update && \
     apt-get install -y locales && \

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.16.5 AS builder
-LABEL maintainer="s.k.noe@hinoshiba.com"
+FROM golang:1.19 AS builder
+LABEL maintainer="jo7oem@ume-ch.net"
 
 ENV GOPATH /go/src
-ENV GO111MODULE=off
 
 ENV LANG ja_JP.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -9,8 +9,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y locales && \
     ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen && \
-    locale-gen ja_JP.UTF-8 && \
+    sed -i -E "s/# (${LANG})/\1/" /etc/locale.gen && \
+    locale-gen && \
     apt-get install -y curl wget tzdata file locales && \
     apt-get install -y vim-nox vim-snippets emacs-nox nano && \
     apt-get clean && \

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     sed -i -E "s/# (${LANG})/\1/" /etc/locale.gen && \
     locale-gen && \
-    apt-get install -y curl wget tzdata file locales && \
+    apt-get install -y curl wget tzdata file locales bash-completion && \
     apt-get install -y vim-nox vim-snippets emacs-nox nano && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -19,4 +19,5 @@ RUN apt-get update && \
 
 ADD ./samples ${GOPATH}/samples/
 ADD ./go_tutorial ${GOPATH}/go_tutorial
+ADD ./container_settings/* /root/
 WORKDIR ${GOPATH}

--- a/src/server-app/go/src/go-tutor/Dockerfile
+++ b/src/server-app/go/src/go-tutor/Dockerfile
@@ -6,13 +6,15 @@ ENV GOPATH /go/src
 ENV LANG ja_JP.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && \
-    apt install -y curl wget tzdata file locales && \
-    apt install -y vim-nox emacs-nox nano && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN apt-get update && \
+    apt-get install -y locales && \
     ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    locale-gen ja_JP.UTF-8
+    sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen && \
+    locale-gen ja_JP.UTF-8 && \
+    apt-get install -y curl wget tzdata file locales && \
+    apt-get install -y vim-nox vim-snippets emacs-nox nano && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD ./samples ${GOPATH}/samples/
 ADD ./go_tutorial ${GOPATH}/go_tutorial

--- a/src/server-app/go/src/go-tutor/Dockerfile-VScode
+++ b/src/server-app/go/src/go-tutor/Dockerfile-VScode
@@ -1,16 +1,19 @@
 FROM jo7oem/go-tutor:latest
 LABEL maintainer="jo7oem@ume-ch.net"
 
-ENV GOPATH /go/src
-
 ENV LANG ja_JP.UTF-8
 
-RUN go install golang.org/x/tools/gopls@latest
+ENV GOPATH /go/src
+ENV GO111MODULE=on
+
+RUN go install golang.org/x/tools/gopls@latest &&\
+    go install github.com/go-delve/delve/cmd/dlv@latest
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 RUN code-server \
   --install-extension ms-ceintl.vscode-language-pack-ja \
   --install-extension golang.Go
 ADD ./VSCode_config.yaml /root/.config/code-server/config.yaml
 
+ENV GO111MODULE=off
 EXPOSE 8080
 ENTRYPOINT ["code-server"]

--- a/src/server-app/go/src/go-tutor/Dockerfile-VScode
+++ b/src/server-app/go/src/go-tutor/Dockerfile-VScode
@@ -1,0 +1,16 @@
+FROM jo7oem/go-tutor:latest
+LABEL maintainer="jo7oem@ume-ch.net"
+
+ENV GOPATH /go/src
+
+ENV LANG ja_JP.UTF-8
+
+RUN go install golang.org/x/tools/gopls@latest
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+RUN code-server \
+  --install-extension ms-ceintl.vscode-language-pack-ja \
+  --install-extension golang.Go
+ADD ./VSCode_config.yaml /root/.config/code-server/config.yaml
+
+EXPOSE 8080
+ENTRYPOINT ["code-server"]

--- a/src/server-app/go/src/go-tutor/Dockerfile-VScode
+++ b/src/server-app/go/src/go-tutor/Dockerfile-VScode
@@ -15,5 +15,5 @@ RUN code-server \
 ADD ./VSCode_config.yaml /root/.config/code-server/config.yaml
 
 ENV GO111MODULE=off
-EXPOSE 8080
+EXPOSE 8888
 ENTRYPOINT ["code-server"]

--- a/src/server-app/go/src/go-tutor/VSCode_config.yaml
+++ b/src/server-app/go/src/go-tutor/VSCode_config.yaml
@@ -1,4 +1,4 @@
-bind-addr: 0.0.0.0:8080
+bind-addr: 0.0.0.0:8888
 auth: password
 password: iij-bootcamp
 cert: false

--- a/src/server-app/go/src/go-tutor/VSCode_config.yaml
+++ b/src/server-app/go/src/go-tutor/VSCode_config.yaml
@@ -1,0 +1,4 @@
+bind-addr: 0.0.0.0:8080
+auth: password
+password: iij-bootcamp
+cert: false

--- a/src/server-app/go/src/go-tutor/container_settings/.bashrc
+++ b/src/server-app/go/src/go-tutor/container_settings/.bashrc
@@ -1,0 +1,4 @@
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'

--- a/src/server-app/go/src/go-tutor/container_settings/.vimrc
+++ b/src/server-app/go/src/go-tutor/container_settings/.vimrc
@@ -1,0 +1,2 @@
+set showmatch matchtime=1
+set mouse=a

--- a/src/server-app/go/src/go-tutor/samples/7_webapp/weakShop/gyudon-httpd.go
+++ b/src/server-app/go/src/go-tutor/samples/7_webapp/weakShop/gyudon-httpd.go
@@ -1,12 +1,15 @@
 package main
 
 import (
-	"./shop"
 	"./http"
+	"./shop"
 )
 
 func main() {
 	myshop := shop.NewGyudon()
 	http.HandleFunc("/", myshop.Eat)
-	http.ListenAndServe("localhost:8080", nil)
+	err := http.ListenAndServe("localhost:8080", nil)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/src/server-app/go/var/md/init.md
+++ b/src/server-app/go/var/md/init.md
@@ -16,7 +16,7 @@ GoでWebアプリケーションを作る(下準備編)
 * PCにDockerの実行環境がある事
 
 ## 手順
-1. docker imageをpullする
+### 1. docker imageをpullする
 	```shell
 	:# 全員
 	$ docker pull jo7oem/go-tutor:v2022
@@ -28,37 +28,37 @@ GoでWebアプリケーションを作る(下準備編)
 	$ docker images | grep go-tutor
 	hinoshiba/go-tutor   latest              <image id>        x minutes ago        <size>
 	```
-2. docker imageを実行する
+### 2. docker imageを実行する
 	```shell
 	$ docker run --name go-tutor -it --rm jo7oem/go-tutor:v2022 /bin/bash
 	root@<container id>:/go/src/samples#   # プロンプトが返ってくる
 	```
-3. 作業ディレクトリの確認
+### 3. 作業ディレクトリの確認
     ```shell
     root@<container id>:/go/src/# ls
     go_tutorial  samples
     ```
    
-4. 任意のエディタ起動確認
-   1. 注意事項: DockerContainerの話
+### 4. 任意のエディタ起動確認
+#### 4.0. 注意事項: DockerContainerの話
    
-      * コンテナは、停止するとデータが **保存されません**
-      * そのため、`.vimrc`のような設定ファイルを頑張って保存しても、コンテナを停止すると消えます
+   * コンテナは、停止するとデータが **保存されません**
+   * そのため、`.vimrc`のような設定ファイルを頑張って保存しても、コンテナを停止すると消えます
+
+#### 4.1. CLIで作業する場合
+   ```shell
+   :# 下記3つ、どちらでも大丈夫です
+   root@<container id>:/go/src/# vim
+   root@<container id>:/go/src/# nano
+   root@<container id>:/go/src/# emacs
+   ```
       
-   2. CLIで作業する場合
-      ```shell
-      :# 下記3つ、どちらでも大丈夫です
-      root@<container id>:/go/src/# vim
-      root@<container id>:/go/src/# nano
-      root@<container id>:/go/src/# emacs
-      ```
-      
-   3. VSCodeで作業する場合
-      1. VSCode Serverを起動します
+#### 4.2. VSCodeで作業する場合
+##### 4.2.1. VSCode Serverを起動します
       ```shell
          :# VSCode Server の起動
          $  docker run --name go-tutor-vscode -p 8888:8888 -itd --rm jo7oem/go-tutor-vscode
       ```
    
-      2. ブラウザで`http://localhost:8888`にアクセス
-      3. パスワードを聞かれた場合は`iij-bootcamp`と入力
+##### 4.2.2. ブラウザで`http://localhost:8888`にアクセス
+##### 4.2.3. パスワードを聞かれた場合は`iij-bootcamp`と入力

--- a/src/server-app/go/var/md/init.md
+++ b/src/server-app/go/var/md/init.md
@@ -10,15 +10,19 @@ GoでWebアプリケーションを作る(下準備編)
 	* vim-nox
 	* emacs-nox
 	* nano
+    * VSCode
 
 ## 前提条件
 * PCにDockerの実行環境がある事
-* CLIでエディタを触れる心
 
 ## 手順
 1. docker imageをpullする
 	```shell
-	$ docker pull hinoshiba/go-tutor:v2021r2
+	:# 全員
+	$ docker pull jo7oem/go-tutor:v2022
+ 
+	:# VSCodeの人はこのImageも
+	$ docker pull jo7oem/go-tutor-vscode:v2022
 	...
 	:# 確認コマンド
 	$ docker images | grep go-tutor
@@ -26,21 +30,35 @@ GoでWebアプリケーションを作る(下準備編)
 	```
 2. docker imageを実行する
 	```shell
-	$ docker run --name go-tutor -it --rm hinoshiba/go-tutor:v2021r2 /bin/bash
+	$ docker run --name go-tutor -it --rm jo7oem/go-tutor:v2022 /bin/bash
 	root@<container id>:/go/src/samples#   # プロンプトが返ってくる
 	```
 3. 作業ディレクトリの確認
-	```shell
-	root@<container id>:/go/src/# ls
-	go_tutorial  samples
-	```
+    ```shell
+    root@<container id>:/go/src/# ls
+    go_tutorial  samples
+    ```
+   
 4. 任意のエディタ起動確認
-	```shell
-	:# 下記3つ、どちらでも大丈夫です
-	root@<container id>:/go/src/# vim
-	root@<container id>:/go/src/# nano
-	root@<container id>:/go/src/# emacs
-	```
-	* 注意事項: DockerContainerの話
-		* コンテナは、停止するとデータが **保存されません**
-		* そのため、`.vimrc`のような設定ファイルを頑張って保存しても、コンテナを停止すると消えます
+   1. 注意事項: DockerContainerの話
+   
+      * コンテナは、停止するとデータが **保存されません**
+      * そのため、`.vimrc`のような設定ファイルを頑張って保存しても、コンテナを停止すると消えます
+      
+   2. CLIで作業する場合
+      ```shell
+      :# 下記3つ、どちらでも大丈夫です
+      root@<container id>:/go/src/# vim
+      root@<container id>:/go/src/# nano
+      root@<container id>:/go/src/# emacs
+      ```
+      
+   3. VSCodeで作業する場合
+      1. VSCode Serverを起動します
+      ```shell
+         :# VSCode Server の起動
+         $  docker run --name go-tutor -p 8080:8080 -itd --rm jo7oem/go-tutor-vscode
+      ```
+   
+      2. ブラウザで`http://localhost:8080`にアクセス
+      3. パスワードを聞かれた場合は`iij-bootcamp`と入力

--- a/src/server-app/go/var/md/init.md
+++ b/src/server-app/go/var/md/init.md
@@ -57,8 +57,8 @@ GoでWebアプリケーションを作る(下準備編)
       1. VSCode Serverを起動します
       ```shell
          :# VSCode Server の起動
-         $  docker run --name go-tutor -p 8080:8080 -itd --rm jo7oem/go-tutor-vscode
+         $  docker run --name go-tutor-vscode -p 8888:8888 -itd --rm jo7oem/go-tutor-vscode
       ```
    
-      2. ブラウザで`http://localhost:8080`にアクセス
+      2. ブラウザで`http://localhost:8888`にアクセス
       3. パスワードを聞かれた場合は`iij-bootcamp`と入力


### PR DESCRIPTION
- Goのバージョンを1.19に更新
- コンテナのlocale設定が効いていなかったのを修正
- VSCode Server入コンテナを追加し、ブラウザ経由でVSCodeが使用できるようにした