### PR TITLE
Bootcamp本番時に見つかった問題を修正

### DIFF
--- a/src/server-app/java/README.md
+++ b/src/server-app/java/README.md
@@ -58,7 +58,7 @@ $ PROXY_PORT=YOUR_PROXY_PORT
 $ JAVA_OPT="-Dhttp.proxyHost=${PROXY_HOST} -Dhttp.proxyPort=${PROXY_PORT} -Dhttps.proxyHost=${PROXY_HOST} -Dhttps.proxyPort=${PROXY_PORT}"
 # プロキシ設定ここまで
 # コンテナを起動する
-$ docker run --name bootcamp-springboot -itd -p 8080:8080 -e JAVA_OPT=${JAVA_OPT} tamago0224/bootcamp-springboot:2022
+$ docker run --name bootcamp-springboot -itd -p 8080:8080 -e JAVA_OPT="${JAVA_OPT}" tamago0224/bootcamp-springboot:2022
 ```
 
 3. アプリケーションの起動チェック


### PR DESCRIPTION
- `JAVA_OPT` シェル変数を渡す際にダブルクォートで囲っていなかったため、`-Dhttp.proxyPort=${PROXY_PORT}`以降が `docker` コマンドに渡ってしまっていたのを修正

@tamago0224 今日のブートキャンプ実施時に見つかった問題を修正しました。ご査収ください 🙇 
