### PR TITLE
Go学習用のVSCode serverのTerminalでGoコマンドのPATHが通るようにする

### DIFF
--- a/src/server-app/go/src/go-tutor/Dockerfile-VScode
+++ b/src/server-app/go/src/go-tutor/Dockerfile-VScode
@@ -13,6 +13,7 @@ RUN code-server \
   --install-extension ms-ceintl.vscode-language-pack-ja \
   --install-extension golang.Go
 ADD ./VSCode_config.yaml /root/.config/code-server/config.yaml
+ADD ./VSCode_settings.json /root/.local/share/code-server/User/settings.json
 
 ENV GO111MODULE=off
 EXPOSE 8888

--- a/src/server-app/go/src/go-tutor/VSCode_settings.json
+++ b/src/server-app/go/src/go-tutor/VSCode_settings.json
@@ -1,0 +1,3 @@
+{
+    "terminal.integrated.inheritEnv": false
+}


### PR DESCRIPTION
### 事象
[GoでWebアプリケーションを作る(下準備編)](https://iij.github.io/bootcamp/server-app/go/var/md/init.html)
上述の手順に沿ってVSCode Serverのためのコンテナを準備しました。
その際にVSCode ServerのTerminalを利用すると以下のようにPATHに`/usr/local/go/bin`がありませんでした。

<img width="835" alt="code-server-terminal" src="https://user-images.githubusercontent.com/61368544/189496513-e9c4c382-f44f-43aa-90b2-57f29516c188.png">

### 対応
VSCode ServerのTerminal利用時のPATHにgoコマンドのパスが追加されるように以下のsettingsを読み込ませるようにしました。
[`terminal.integrated.inheritEnv`](https://code.visualstudio.com/docs/getstarted/settings#:~:text=terminal.integrated.inheritEnv)

### 備考
細かめの修正なのでissueなしとさせていただきました。