### PR TITLE
docker/getting-started の扱いについて追記

### DIFF
--- a/src/development/docker/docker/GETSTART.md
+++ b/src/development/docker/docker/GETSTART.md
@@ -87,7 +87,23 @@ getting-startedでは予めビルド済みイメージを公開している為�
 
 
 ```bash
- docker run --rm --name iijbootcamp_docker01-tutorial getting-started
+ docker run --rm --name iijbootcamp_docker01-tutorial docker/getting-started
+```
+
+また、 この ```docker/getting-started``` image を ```iijbootcamp_docker01``` と呼べるようにしておきましょう
+
+```
+docker tag docker/getting-started iijbootcamp_docker01
+```
+
+```docker images``` コマンドで今 pull してあったり build して用意した image が確認できます。
+
+```bash
+$ docker images
+
+REPOSITORY               TAG       IMAGE ID       CREATED          SIZE
+docker/getting-started   latest    3e4394f6b72f   6 months ago     47MB
+iijbootcamp_docker01     latest    3e4394f6b72f   6 months ago     47MB
 ```
 
 ### 発展課題


### PR DESCRIPTION
docker/GETSTART.md では

docker build ができない人のために

```
docker run --rm --name iijbootcamp_docker01-tutorial getting-started
```
が紹介されていますが

正しくは
https://github.com/docker/getting-started
にあるとおり
docker/getting-started のようです

```
docker run -d -p 80:80 docker/getting-started
```

また、 自前build した人と同様のコマンドで後段の手順を進められるように docker tag で 名前をつけ直すのを提案します。