### PR TITLE
コンテナー起動時に直ちにアタッチする

### DIFF
--- a/src/server-app/java/README.md
+++ b/src/server-app/java/README.md
@@ -58,14 +58,12 @@ $ PROXY_PORT=YOUR_PROXY_PORT
 $ JAVA_OPT="-Dhttp.proxyHost=${PROXY_HOST} -Dhttp.proxyPort=${PROXY_PORT} -Dhttps.proxyHost=${PROXY_HOST} -Dhttps.proxyPort=${PROXY_PORT}"
 # プロキシ設定ここまで
 # コンテナを起動する
-$ docker run --name bootcamp-springboot -itd -p 8080:8080 -e JAVA_OPT="${JAVA_OPT}" tamago0224/bootcamp-springboot:2023
+$ docker run --name bootcamp-springboot -it -p 8080:8080 -e JAVA_OPT="${JAVA_OPT}" tamago0224/bootcamp-springboot:2023
 ```
 
 3. アプリケーションの起動チェック
 
 ```bash
-# コンテナの中にアタッチする
-$ docker exec -it bootcamp-springboot bash
 # Spring Bootを起動する
 ❯ ./gradlew bootrun
 # ...


### PR DESCRIPTION
`docker run` 実行時に `-d` を付けることで、コンテナーの起動とコンテナーでbashを起動するのを敢えて別のコマンドにしているようですが、そうするメリットが特に思い浮かばなかったので `-d` オプションを削除しました。

何か誤解していたらすみません！
（iij organizationに所属していないのかreviewerに追加できなかったのでメンションします @tamago0224 ）