### PR TITLE
2026年度カリキュラムへの更新

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -4,10 +4,10 @@ heroImage: "/barry-bootcamp.png"
 actionText: "IIJ Bootcampとは？"
 actionLink: /about/
 features:
-footer: CC BY-SA Licensed | Copyright (c) 2025, Internet Initiative Japan Inc.
+footer: CC BY-SA Licensed | Copyright (c) 2026, Internet Initiative Japan Inc.
 ---
 
-## 2025年度カリキュラム一覧
+## 2026年度カリキュラム一覧
 
 | カテゴリ | 1枠目 | 2枠目 | 3枠目 | 4枠目 | 5枠目 |
 | :--: | :--: | :--: | :--: | :--: | :--: |

--- a/src/README.md
+++ b/src/README.md
@@ -12,11 +12,11 @@ footer: CC BY-SA Licensed | Copyright (c) 2025, Internet Initiative Japan Inc.
 | カテゴリ | 1枠目 | 2枠目 | 3枠目 | 4枠目 | 5枠目 |
 | :--: | :--: | :--: | :--: | :--: | :--: |
 | **イントロ** | イントロダクション<br>(社内限定資料) | 事前準備<br>(社内限定資料)| 事前準備<br>(社内限定資料) |
-| **開発** | [Gitの使い方](development/git/)+[GitHubを使った開発手法<br>(最新版は社内限定資料)](development/github/) | [開発環境をDockerで構築](development/docker/docker/)+[docker-compose](development/docker/docker-compose/)
+| **開発** | [Gitの使い方](development/git/)+[GitHubを使った開発手法<br>(最新版は社内限定資料)](development/github/) | [開発環境をDockerで構築](development/docker/docker/)+[docker-compose](development/docker/docker-compose/) |
 | **CI/CD + 構成管理** | [GitHub Actions ハンズオン](cicd_infra/github_actions/) | [ansibleによるIT自動化](cicd_infra/ansible/) | [Kubernetes ハンズオン](development/kubernetes/) |
-| **監視・モニタリング** | [監視Overview](cicd_infra/prometheus/) | [Prometheusハンズオン](cicd_infra/prometheus/) | Splunkハンズオン<br>(社内限定資料) | [OpenTelemetryハンズオン](cicd_infra/opentelemetry/) | 
-| **データベース** | [データベースOverview](database/overview/) | [リレーショナルDBを触ってみる](database/postgresql/) | [MongoDBを触ってみる](database/mongodb/) | [redisを触ってみる](database/redis/) |
+| **監視・モニタリング** | [監視Overview](cicd_infra/prometheus/) | [Prometheusハンズオン](cicd_infra/prometheus/) | Splunkハンズオン<br>(社内限定資料) | [OpenTelemetryハンズオン](cicd_infra/opentelemetry/) | Lokiハンズオン |
+| **データベース** | [データベースOverview](database/overview/) | [リレーショナルDBを触ってみる](database/postgresql/) | [MongoDBを触ってみる](database/mongodb/) |
 | **Webサーバー** | HTTP Overview<br>(社内限定資料) | [Apache + NginxでWebサーバーを立てよう](web-server/apache_nginx/) | [SSL/TLSハンズオン](web-server/tls/) | DNSハンズオン<br>(社内限定資料) |
-| **バックエンドアプリ** | [バックエンドアプリOverview](/server-app/overview/) | [Java: Springハンズオン](server-app/java/) | [GoでWebアプリを作る](server-app/go/) | [並行処理ハンズオン](server-app/concurrent) | [テストプログラミングハンズオン](server-app/test-hands-on) |
+| **バックエンドアプリ** | [バックエンドアプリOverview](/server-app/overview/) | [FastAPIを使ったAPIサーバ作り](server-app/fastapi/) | [GoでWebアプリを作る](server-app/go/) | [並行処理ハンズオン](server-app/concurrent) | [テストプログラミングハンズオン](server-app/test-hands-on) |
 | **フロントエンド** | [素のJavaScript + DOM入門](frontend/dom/) | [Reactを触ってみよう](frontend/react/) | [LLMでWebアプリケーションを作ろう](frontend/vibecoding/) |
 | **セキュリティ** | [WebアプリとセキュリティOverview](security/overview/) | アプリに認証を導入するハンズオン<br>(社内限定資料) | セキュリティハンズオン<br>(社内限定資料) |


### PR DESCRIPTION
カリキュラムが2025年度のものになっていたため2026年度のものに更新しました

Lokiハンズオンに関してはLokiの資料がpushされていないため、まだリンクは追加しておりません